### PR TITLE
user can now update pins

### DIFF
--- a/src/javascripts/components/cards/pins.js
+++ b/src/javascripts/components/cards/pins.js
@@ -5,6 +5,7 @@ const pinMaker = (pinObject) => {
                       <a href="${pinObject.url}"><img class="card-img-top" src="${pinObject.imageUrl}" alt=${pinObject.description}"></a>
                       <div class="card-body d-flex justify-content-between">
                         <p class="text-left">${pinObject.description}</p>
+                        <i class="fas fa-pen edit-btn" id="${pinObject.pinId}"></i>
                         <i class="fas fa-trash-alt delete-btn" id="${pinObject.pinId}"></i>
                       </div>
                     </div>`;

--- a/src/javascripts/components/forms/updatePinForm.js
+++ b/src/javascripts/components/forms/updatePinForm.js
@@ -1,0 +1,50 @@
+import pinsData from '../../helpers/data/pinsData';
+import boardsData from '../../helpers/data/boardsData';
+
+const updatePinForm = (pinObject) => {
+  $('#update-pin-form').html(`<form class="form">
+                                <div class="form-group">
+                                  <label for="siteUrlInput">Pin Link</label>
+                                  <input type="text" class="form-control" id="siteUrlInput" value="${pinObject.url}">
+                                </div>
+                                <div class="form-group">
+                                  <label for="pinImageUrlInput">Pin Image</label>
+                                  <input type="text" class="form-control" id="pinImageUrlInput" value="${pinObject.imageUrl}">
+                                </div>
+                                <div class="form-group">
+                                  <label for="descriptionInput">Description</label>
+                                  <input type="text" class="form-control" id="descriptionInput" value=${pinObject.description}>
+                                </div>
+                                <div class="form-group">
+                                  <label for="boardSelection">Board</label>
+                                  <select class="form-control" id="boardSelection">
+                                    <option value="">Select a Board</option>
+                                  </select>
+                                </div>
+                                <div id="error-message"></div>
+                                <button type="submit" class="btn btn-primary" id="update-pin-submit">Submit</button>
+                              </form>
+  `);
+  boardsData.getAllBoards().then((response) => {
+    response.forEach((board) => {
+      $('#boardSelection').append(`<option value="${board.boardId}" ${pinObject.boardId === board.boardId ? "selected='selected'" : ''}>${board.name}</option>`);
+    });
+  });
+  $('#update-pin-submit').on('click', (e) => {
+    e.preventDefault();
+    const data = {
+      boardId: $('#boardSelection').val() || false,
+      url: $('#siteUrlInput').val() || false,
+      imageUrl: $('#pinImageUrlInput').val() || false,
+      description: $('#descriptionInput').val() || false
+    };
+    if (Object.values(data).includes(false)) {
+      $('#error-message').html('<div class="alert alert-danger" role="alert">Please complete all fields</div>');
+    } else {
+      $('#error-message').html('');
+      pinsData.updatePin(pinObject.pinId, data);
+    }
+  });
+};
+
+export default { updatePinForm };

--- a/src/javascripts/components/views/updatePinView.js
+++ b/src/javascripts/components/views/updatePinView.js
@@ -1,0 +1,11 @@
+import pinsData from '../../helpers/data/pinsData';
+import form from '../forms/updatePinForm';
+
+const updatePinView = (pinId) => {
+  $('#app').html('<div id="update-pin-form"></div>');
+  pinsData.getSinglePin(pinId).then((response) => {
+    form.updatePinForm(response);
+  });
+};
+
+export default { updatePinView };

--- a/src/javascripts/helpers/data/pinsData.js
+++ b/src/javascripts/helpers/data/pinsData.js
@@ -17,10 +17,9 @@ const getPins = (boardId) => new Promise((resolve, reject) => {
 });
 
 const getSinglePin = (pinId) => new Promise((resolve, reject) => {
-  axios.get(`${baseUrl}/pins.json?orderBy="pinId"&equalTo="${pinId}"`)
+  axios.get(`${baseUrl}/pins/${pinId}.json`)
     .then((response) => {
-      const pin = Object.values(response.data);
-      const thisPin = pin[0];
+      const thisPin = response.data;
       resolve(thisPin);
     }).catch((error) => reject(error));
 });
@@ -38,4 +37,12 @@ const addPin = (data) => axios.post(`${baseUrl}/pins.json`, data)
     axios.patch(`${baseUrl}/pins/${response.data.name}.json`, update);
   }).catch((error) => console.warn(error));
 
-export default { getPins, deletePin, addPin };
+const updatePin = (pinId, pinObject) => axios.patch(`${baseUrl}/pins/${pinId}.json`, pinObject);
+
+export default {
+  getPins,
+  deletePin,
+  addPin,
+  updatePin,
+  getSinglePin
+};

--- a/src/javascripts/helpers/viewHelper.js
+++ b/src/javascripts/helpers/viewHelper.js
@@ -2,6 +2,7 @@ import addBoardView from '../components/views/addBoardView';
 import addPinView from '../components/views/addPinView';
 import boardsView from '../components/views/boardsView';
 import pinsView from '../components/views/pinsView';
+import updatePinView from '../components/views/updatePinView';
 
 const viewHelper = (id, arg) => {
   switch (id) {
@@ -13,6 +14,8 @@ const viewHelper = (id, arg) => {
       return addBoardView.addBoardView();
     case 'add-pin':
       return addPinView.addPinView();
+    case 'update-pin':
+      return updatePinView.updatePinView(arg);
     default:
       return console.warn('nothing clicked');
   }
@@ -39,6 +42,16 @@ const viewListener = (view) => {
     viewHelper('add-pin');
   });
   $('body').on('click', '#add-pin-submit', () => {
+    const boardId = $('#boardSelection').val();
+    setTimeout(() => {
+      viewHelper('pins', boardId);
+    }, 1000);
+  });
+  $('body').on('click', '.edit-btn', (e) => {
+    const pinId = e.currentTarget.id;
+    viewHelper('update-pin', pinId);
+  });
+  $('body').on('click', '#update-pin-submit', () => {
     const boardId = $('#boardSelection').val();
     setTimeout(() => {
       viewHelper('pins', boardId);


### PR DESCRIPTION
## Description
Added update form so that the user can move pins to different boards or change the information on the pin.

## Related Issue
Resolves #22

## Motivation and Context
The user can change the board for a pin if they want to reorganize their pins.

## How Can This Be Tested?
```git fetch origin update```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
